### PR TITLE
Overlapping ships tested and implemented in valid_placement?

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -93,12 +93,19 @@ class Board
     length = length_equals_coord(ship, coordinate)
     valid_c = valid_coordinates?(coordinate)
     diag_c = diagonal_coords?(ship, coordinate)
+    overlap = overlapping_ships?(ship, coordinate)
     length && valid_c && diag_c
   end
 
   def place(ship, coordinate)
     coordinate.each do |coordinate|
       @cells[coordinate].place_ship(ship)
+    end
+  end
+
+  def overlapping_ships?(ship, coordinate)
+    coordinate.any? do |coordinate|
+      @cells[coordinate].empty?
     end
   end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -93,4 +93,9 @@ class BoardTest < Minitest::Test
     @cell_3.ship
     assert_equal true, @cell_3.ship == @cell_2.ship
   end
+
+  def test_ships_cannot_overlap
+    @board.place(@cruiser, ["A1", "A2", "A3"])
+    assert_equal true, @board.overlapping_ships?(@submarine, ["A1", "B1"])
+  end
 end


### PR DESCRIPTION
What does this PR do?
Prevents ships from being placed on the same cells and overlapping. Implemented into the valid_placement? method too. (I thought of this one on the train back home and wanted to add it in before I lost my idea! Just rendering the board is left for iteration 2!)